### PR TITLE
Remove modification of permissions

### DIFF
--- a/docker-entrypoint.d/25-fix-permissions.sh
+++ b/docker-entrypoint.d/25-fix-permissions.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-chown -R sftp.sftp /var/lib/data


### PR DESCRIPTION
If files are not owned by sftp user (999) changing ownership will
introduce issues in container that share same named volume.
